### PR TITLE
.NET9

### DIFF
--- a/HostCrashGuard/HostCrashGuard.cs
+++ b/HostCrashGuard/HostCrashGuard.cs
@@ -23,9 +23,6 @@ public class HostCrashGuard : ResoniteMod {
 	private static readonly ModConfigurationKey<bool> NetworkPatchesEnabled = new ModConfigurationKey<bool>("Network Patches", "Enable all network crash fixes of this mod.", () => true);
 
 	[AutoRegisterConfigKey]
-	private static readonly ModConfigurationKey<bool> HostDisconnectEnabled = new ModConfigurationKey<bool>("Host Disconnects", "Enable additional checks to prevent worlds from closing.", () => true);
-
-	[AutoRegisterConfigKey]
 	private static readonly ModConfigurationKey<bool> ComponentPatchesEnabled = new ModConfigurationKey<bool>("Component Patches", "Enable all component related crash fixes of this mod.", () => true);
 
 	[AutoRegisterConfigKey]

--- a/HostCrashGuard/HostCrashGuard.cs
+++ b/HostCrashGuard/HostCrashGuard.cs
@@ -13,7 +13,7 @@ using System.Threading;
 namespace HostCrashGuard;
 
 public class HostCrashGuard : ResoniteMod {
-	internal const string VERSION_CONSTANT = "2.4.5"; //Changing the version here updates it in all locations needed
+	internal const string VERSION_CONSTANT = "3.0.0"; //Changing the version here updates it in all locations needed
 	public override string Name => "HostCrashGuard";
 	public override string Author => "__Choco__";
 	public override string Version => VERSION_CONSTANT;

--- a/HostCrashGuard/HostCrashGuard.cs
+++ b/HostCrashGuard/HostCrashGuard.cs
@@ -23,6 +23,9 @@ public class HostCrashGuard : ResoniteMod {
 	private static readonly ModConfigurationKey<bool> NetworkPatchesEnabled = new ModConfigurationKey<bool>("Network Patches", "Enable all network crash fixes of this mod.", () => true);
 
 	[AutoRegisterConfigKey]
+	private static readonly ModConfigurationKey<bool> HostDisconnectEnabled = new ModConfigurationKey<bool>("Host Disconnects", "Enable additional checks to prevent worlds from closing.", () => true);
+
+	[AutoRegisterConfigKey]
 	private static readonly ModConfigurationKey<bool> ComponentPatchesEnabled = new ModConfigurationKey<bool>("Component Patches", "Enable all component related crash fixes of this mod.", () => true);
 
 	[AutoRegisterConfigKey]

--- a/HostCrashGuard/HostCrashGuard.csproj
+++ b/HostCrashGuard/HostCrashGuard.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>HostCrashGuard</RootNamespace>
 		<AssemblyName>HostCrashGuard</AssemblyName>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-		<TargetFramework>net472</TargetFramework>
+		<TargetFramework>net9</TargetFramework>
 		<FileAlignment>512</FileAlignment>
 		<LangVersion>10.0</LangVersion>
 		<Nullable>enable</Nullable>
@@ -26,21 +26,21 @@
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="HarmonyLib">
-			<HintPath>$(ResonitePath)rml_libs\0Harmony.dll</HintPath>
+			<HintPath>$(ResonitePath)rml_libs\0Harmony-NET9.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="FrooxEngine">
-			<HintPath>$(ResonitePath)Resonite_Data\Managed\FrooxEngine.dll</HintPath>
+			<HintPath>$(ResonitePath)\FrooxEngine.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="Elements.Core">
-			<HintPath>$(ResonitePath)Resonite_Data\Managed\Elements.Core.dll</HintPath>
+			<HintPath>$(ResonitePath)\Elements.Core.dll</HintPath>
 		</Reference>
 		<Reference Include="LiteNetLib">
-			<HintPath>$(ResonitePath)Resonite_Data\Managed\LiteNetLib.dll</HintPath>
+			<HintPath>$(ResonitePath)\LiteNetLib.dll</HintPath>
 		</Reference>
 		<Reference Include="ProtoFlux.Nodes.FrooxEngine">
-			<HintPath>$(ResonitePath)Resonite_Data\Managed\ProtoFlux.Nodes.FrooxEngine.dll</HintPath>
+			<HintPath>$(ResonitePath)\ProtoFlux.Nodes.FrooxEngine.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 


### PR DESCRIPTION
Changed library references to .NET9 equivalents.  Changed build target to .NET9.

Looked into feasibility of keeping world open after afk kicks or world closes, while retaining the disconnection for kicks/bans as a possible solution for #11. Unfortunately, a world close, afk kick, manual kick, and ban are all able to/will always appear identical to a client. For this reason, I am closing the issue as I am unable to find any way to solve it without also breaking Resonites TOS.